### PR TITLE
add keytrack panning

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,10 @@
 
 Converted from the original GigaSampler version by S. Christian Collins
 www.schristiancollins.com
+
+## Changelog
+
+* 1.1
+   - The samples are mono, but I wanted to create a better sense of space, so I implemented stereo keytrack panning with low notes on the left and high notes on the right of the stereo field. The amount of keytrack panning can be controlled using CC#21 and is set to 50% (64) by default.
+* 1.0
+   - Initial conversion from the original GigaSampler version.

--- a/data/control.sfzh
+++ b/data/control.sfzh
@@ -1,3 +1,4 @@
 <control>
 default_path=samples/
-label_cc11=Expression  set_cc11=127
+label_cc11=Expression     set_cc11=127
+label_cc21=Stereo Spread  set_cc21=64

--- a/data/master.sfzh
+++ b/data/master.sfzh
@@ -1,1 +1,7 @@
 <master> ampeg_release=0.6  amp_veltrack=0  amplitude_oncc11=100
+
+var01_pan=200
+var01_mod=mult
+var01_oncc21=1
+var01_oncc133=1
+var01_curvecc133=1


### PR DESCRIPTION
The samples are mono, but I wanted to create a better sense of space, so I implemented stereo keytrack panning with low notes on the left and high notes on the right of the stereo field. The amount of keytrack panning can be controlled using CC#21 and is set to 50% (64) by default.